### PR TITLE
Add support for Material3Expressive styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,20 @@ $ yarn add react-native-edge-to-edge
 
 This library requires you to update the parent of your Android `AppTheme` to an edge-to-edge version. Don't worry, it's very easy to understand! You just need to choose a theme based on the current value:
 
-| If you currently have…                               | …you should use                            |
-| :--------------------------------------------------- | :----------------------------------------- |
-| `Theme.AppCompat.DayNight.NoActionBar`               | `Theme.EdgeToEdge`                         |
-| `Theme.MaterialComponents.DayNight.NoActionBar`      | `Theme.EdgeToEdge.Material2`               |
-| `Theme.Material3.DayNight.NoActionBar`               | `Theme.EdgeToEdge.Material3`               |
-| `Theme.Material3.DynamicColors.DayNight.NoActionBar` | `Theme.EdgeToEdge.Material3.Dynamic`       |
-| `Theme.AppCompat.Light.NoActionBar`                  | `Theme.EdgeToEdge.Light`                   |
-| `Theme.MaterialComponents.Light.NoActionBar`         | `Theme.EdgeToEdge.Material2.Light`         |
-| `Theme.Material3.Light.NoActionBar`                  | `Theme.EdgeToEdge.Material3.Light`         |
-| `Theme.Material3.DynamicColors.Light.NoActionBar`    | `Theme.EdgeToEdge.Material3.Dynamic.Light` |
+| If you currently have…                                         | …you should use                                      |
+| :------------------------------------------------------------- | :--------------------------------------------------- |
+| `Theme.AppCompat.DayNight.NoActionBar`                         | `Theme.EdgeToEdge`                                   |
+| `Theme.MaterialComponents.DayNight.NoActionBar`                | `Theme.EdgeToEdge.Material2`                         |
+| `Theme.Material3.DayNight.NoActionBar`                         | `Theme.EdgeToEdge.Material3`                         |
+| `Theme.Material3.DynamicColors.DayNight.NoActionBar`           | `Theme.EdgeToEdge.Material3.Dynamic`                 |
+| `Theme.Material3Expressive.DayNight.NoActionBar`               | `Theme.EdgeToEdge.Material3Expressive`               |
+| `Theme.Material3Expressive.DynamicColors.DayNight.NoActionBar` | `Theme.EdgeToEdge.Material3Expressive.Dynamic`       |
+| `Theme.AppCompat.Light.NoActionBar`                            | `Theme.EdgeToEdge.Light`                             |
+| `Theme.MaterialComponents.Light.NoActionBar`                   | `Theme.EdgeToEdge.Material2.Light`                   |
+| `Theme.Material3.Light.NoActionBar`                            | `Theme.EdgeToEdge.Material3.Light`                   |
+| `Theme.Material3.DynamicColors.Light.NoActionBar`              | `Theme.EdgeToEdge.Material3.Dynamic.Light`           |
+| `Theme.Material3Expressive.Light.NoActionBar`                  | `Theme.EdgeToEdge.Material3Expressive.Light`         |
+| `Theme.Material3Expressive.DynamicColors.Light.NoActionBar`    | `Theme.EdgeToEdge.Material3Expressive.Dynamic.Light` |
 
 ### Expo
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,5 +70,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+" // From node_modules
-    implementation "com.google.android.material:material:${safeExtGet("materialVersion", "1.12.0")}"
+    implementation "com.google.android.material:material:${safeExtGet("materialVersion", "1.14.0-alpha01")}"
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -70,5 +70,5 @@ repositories {
 dependencies {
     //noinspection GradleDynamicVersion
     implementation "com.facebook.react:react-native:+" // From node_modules
-    implementation "com.google.android.material:material:${safeExtGet("materialVersion", "1.14.0-alpha01")}"
+    implementation "com.google.android.material:material:${safeExtGet("materialVersion", "1.14.0-alpha03")}"
 }

--- a/android/src/main/res/values-v27/styles.xml
+++ b/android/src/main/res/values-v27/styles.xml
@@ -20,6 +20,16 @@
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>
 
+    <style name="Theme.EdgeToEdge.Material3Expressive" parent="Theme.EdgeToEdge.Material3Expressive.DayNight.Common">
+        <item name="android:windowLightNavigationBar">@bool/windowLightSystemBars</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+
+    <style name="Theme.EdgeToEdge.Material3Expressive.Dynamic" parent="Theme.EdgeToEdge.Material3Expressive.Dynamic.DayNight.Common">
+        <item name="android:windowLightNavigationBar">@bool/windowLightSystemBars</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+
     <style name="Theme.EdgeToEdge.Light" parent="Theme.EdgeToEdge.Light.Common">
         <item name="android:windowLightNavigationBar">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
@@ -36,6 +46,16 @@
     </style>
 
     <style name="Theme.EdgeToEdge.Material3.Dynamic.Light" parent="Theme.EdgeToEdge.Material3.Dynamic.Light.Common">
+        <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+
+    <style name="Theme.EdgeToEdge.Material3Expressive.Light" parent="Theme.EdgeToEdge.Material3Expressive.Light.Common">
+        <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+    </style>
+
+    <style name="Theme.EdgeToEdge.Material3Expressive.Dynamic.Light" parent="Theme.EdgeToEdge.Material3Expressive.Dynamic.Light.Common">
         <item name="android:windowLightNavigationBar">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
     </style>

--- a/android/src/main/res/values-v29/styles.xml
+++ b/android/src/main/res/values-v29/styles.xml
@@ -28,6 +28,20 @@
         <item name="android:enforceNavigationBarContrast">?enforceNavigationBarContrast</item>
     </style>
 
+    <style name="Theme.EdgeToEdge.Material3Expressive" parent="Theme.EdgeToEdge.Material3Expressive.DayNight.Common">
+        <item name="android:windowLightNavigationBar">@bool/windowLightSystemBars</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">?enforceNavigationBarContrast</item>
+    </style>
+
+    <style name="Theme.EdgeToEdge.Material3Expressive.Dynamic" parent="Theme.EdgeToEdge.Material3Expressive.Dynamic.DayNight.Common">
+        <item name="android:windowLightNavigationBar">@bool/windowLightSystemBars</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">?enforceNavigationBarContrast</item>
+    </style>
+
     <style name="Theme.EdgeToEdge.Light" parent="Theme.EdgeToEdge.Light.Common">
         <item name="android:windowLightNavigationBar">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
@@ -50,6 +64,20 @@
     </style>
 
     <style name="Theme.EdgeToEdge.Material3.Dynamic.Light" parent="Theme.EdgeToEdge.Material3.Dynamic.Light.Common">
+        <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">?enforceNavigationBarContrast</item>
+    </style>
+
+    <style name="Theme.EdgeToEdge.Material3Expressive.Light" parent="Theme.EdgeToEdge.Material3Expressive.Light.Common">
+        <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">?enforceNavigationBarContrast</item>
+    </style>
+
+    <style name="Theme.EdgeToEdge.Material3Expressive.Dynamic.Light" parent="Theme.EdgeToEdge.Material3Expressive.Dynamic.Light.Common">
         <item name="android:windowLightNavigationBar">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">shortEdges</item>
         <item name="android:enforceStatusBarContrast">false</item>

--- a/android/src/main/res/values-v30/styles.xml
+++ b/android/src/main/res/values-v30/styles.xml
@@ -28,6 +28,20 @@
         <item name="android:enforceNavigationBarContrast">?enforceNavigationBarContrast</item>
     </style>
 
+    <style name="Theme.EdgeToEdge.Material3Expressive" parent="Theme.EdgeToEdge.Material3Expressive.DayNight.Common">
+        <item name="android:windowLightNavigationBar">@bool/windowLightSystemBars</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">always</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">?enforceNavigationBarContrast</item>
+    </style>
+
+    <style name="Theme.EdgeToEdge.Material3Expressive.Dynamic" parent="Theme.EdgeToEdge.Material3Expressive.Dynamic.DayNight.Common">
+        <item name="android:windowLightNavigationBar">@bool/windowLightSystemBars</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">always</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">?enforceNavigationBarContrast</item>
+    </style>
+
     <style name="Theme.EdgeToEdge.Light" parent="Theme.EdgeToEdge.Light.Common">
         <item name="android:windowLightNavigationBar">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">always</item>
@@ -50,6 +64,20 @@
     </style>
 
     <style name="Theme.EdgeToEdge.Material3.Dynamic.Light" parent="Theme.EdgeToEdge.Material3.Dynamic.Light.Common">
+        <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">always</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">?enforceNavigationBarContrast</item>
+    </style>
+
+    <style name="Theme.EdgeToEdge.Material3Expressive.Light" parent="Theme.EdgeToEdge.Material3Expressive.Light.Common">
+        <item name="android:windowLightNavigationBar">true</item>
+        <item name="android:windowLayoutInDisplayCutoutMode">always</item>
+        <item name="android:enforceStatusBarContrast">false</item>
+        <item name="android:enforceNavigationBarContrast">?enforceNavigationBarContrast</item>
+    </style>
+
+    <style name="Theme.EdgeToEdge.Material3Expressive.Dynamic.Light" parent="Theme.EdgeToEdge.Material3Expressive.Dynamic.Light.Common">
         <item name="android:windowLightNavigationBar">true</item>
         <item name="android:windowLayoutInDisplayCutoutMode">always</item>
         <item name="android:enforceStatusBarContrast">false</item>

--- a/android/src/main/res/values/public.xml
+++ b/android/src/main/res/values/public.xml
@@ -6,9 +6,13 @@
     <public name="Theme.EdgeToEdge.Material2" type="style" />
     <public name="Theme.EdgeToEdge.Material3" type="style" />
     <public name="Theme.EdgeToEdge.Material3.Dynamic" type="style" />
+    <public name="Theme.EdgeToEdge.Material3Expressive" type="style" />
+    <public name="Theme.EdgeToEdge.Material3Expressive.Dynamic" type="style" />
 
     <public name="Theme.EdgeToEdge.Light" type="style" />
     <public name="Theme.EdgeToEdge.Material2.Light" type="style" />
     <public name="Theme.EdgeToEdge.Material3.Light" type="style" />
     <public name="Theme.EdgeToEdge.Material3.Dynamic.Light" type="style" />
+    <public name="Theme.EdgeToEdge.Material3Expressive.Light" type="style" />
+    <public name="Theme.EdgeToEdge.Material3Expressive.Dynamic.Light" type="style" />
 </resources>

--- a/android/src/main/res/values/styles.xml
+++ b/android/src/main/res/values/styles.xml
@@ -44,6 +44,28 @@
         <item name="android:windowLightStatusBar">@bool/windowLightSystemBars</item>
     </style>
 
+    <style name="Theme.EdgeToEdge.Material3Expressive.DayNight.Common" parent="Theme.Material3Expressive.DayNight.NoActionBar">
+        <item name="enforceNavigationBarContrast">true</item>
+        <item name="enforceSystemBarsLightTheme">false</item>
+
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:fitsSystemWindows">false</item>
+        <item name="android:navigationBarColor">@color/navigationBarColor</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">@bool/windowLightSystemBars</item>
+    </style>
+
+    <style name="Theme.EdgeToEdge.Material3Expressive.Dynamic.DayNight.Common" parent="Theme.Material3Expressive.DynamicColors.DayNight.NoActionBar">
+        <item name="enforceNavigationBarContrast">true</item>
+        <item name="enforceSystemBarsLightTheme">false</item>
+
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:fitsSystemWindows">false</item>
+        <item name="android:navigationBarColor">@color/navigationBarColor</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">@bool/windowLightSystemBars</item>
+    </style>
+
     <style name="Theme.EdgeToEdge.Light.Common" parent="Theme.AppCompat.Light.NoActionBar">
         <item name="enforceNavigationBarContrast">true</item>
         <item name="enforceSystemBarsLightTheme">true</item>
@@ -88,13 +110,39 @@
         <item name="android:windowLightStatusBar">true</item>
     </style>
 
+    <style name="Theme.EdgeToEdge.Material3Expressive.Light.Common" parent="Theme.Material3Expressive.Light.NoActionBar">
+        <item name="enforceNavigationBarContrast">true</item>
+        <item name="enforceSystemBarsLightTheme">false</item>
+
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:fitsSystemWindows">false</item>
+        <item name="android:navigationBarColor">@color/navigationBarColor</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">@bool/windowLightSystemBars</item>
+    </style>
+
+    <style name="Theme.EdgeToEdge.Material3Expressive.Dynamic.Light.Common" parent="Theme.Material3Expressive.DynamicColors.Light.NoActionBar">
+        <item name="enforceNavigationBarContrast">true</item>
+        <item name="enforceSystemBarsLightTheme">false</item>
+
+        <item name="android:windowDrawsSystemBarBackgrounds">true</item>
+        <item name="android:fitsSystemWindows">false</item>
+        <item name="android:navigationBarColor">@color/navigationBarColor</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">@bool/windowLightSystemBars</item>
+    </style>
+
     <style name="Theme.EdgeToEdge" parent="Theme.EdgeToEdge.DayNight.Common" />
     <style name="Theme.EdgeToEdge.Material2" parent="Theme.EdgeToEdge.Material2.DayNight.Common" />
     <style name="Theme.EdgeToEdge.Material3" parent="Theme.EdgeToEdge.Material3.DayNight.Common" />
     <style name="Theme.EdgeToEdge.Material3.Dynamic" parent="Theme.EdgeToEdge.Material3.Dynamic.DayNight.Common" />
+    <style name="Theme.EdgeToEdge.Material3Expressive" parent="Theme.EdgeToEdge.Material3Expressive.DayNight.Common" />
+    <style name="Theme.EdgeToEdge.Material3Expressive.Dynamic" parent="Theme.EdgeToEdge.Material3Expressive.Dynamic.DayNight.Common" />
 
     <style name="Theme.EdgeToEdge.Light" parent="Theme.EdgeToEdge.Light.Common" />
     <style name="Theme.EdgeToEdge.Material2.Light" parent="Theme.EdgeToEdge.Material2.Light.Common" />
     <style name="Theme.EdgeToEdge.Material3.Light" parent="Theme.EdgeToEdge.Material3.Light.Common" />
     <style name="Theme.EdgeToEdge.Material3.Dynamic.Light" parent="Theme.EdgeToEdge.Material3.Dynamic.Light.Common" />
+    <style name="Theme.EdgeToEdge.Material3Expressive.Light" parent="Theme.EdgeToEdge.Material3Expressive.Light.Common" />
+    <style name="Theme.EdgeToEdge.Material3Expressive.Dynamic.Light" parent="Theme.EdgeToEdge.Material3Expressive.Dynamic.Light.Common" />
 </resources>

--- a/src/expo.ts
+++ b/src/expo.ts
@@ -9,10 +9,14 @@ type ParentTheme =
   | "Material2"
   | "Material3"
   | "Material3.Dynamic"
+  | "Material3Expressive"
+  | "Material3Expressive.Dynamic"
   | "Light"
   | "Material2.Light"
   | "Material3.Light"
-  | "Material3.Dynamic.Light";
+  | "Material3.Dynamic.Light"
+  | "Material3Expressive.Light"
+  | "Material3Expressive.Dynamic.Light";
 
 type AndroidProps = {
   enforceNavigationBarContrast?: boolean;
@@ -30,11 +34,15 @@ const withAndroidEdgeToEdgeTheme: ConfigPlugin<Props> = (
     Material2: "Theme.EdgeToEdge.Material2",
     Material3: "Theme.EdgeToEdge.Material3",
     "Material3.Dynamic": "Theme.EdgeToEdge.Material3.Dynamic",
+    "Material3Expressive": "Theme.EdgeToEdge.Material3Expressive",
+    "Material3Expressive.Dynamic": "Theme.EdgeToEdge.Material3Expressive.Dynamic",
 
     Light: "Theme.EdgeToEdge.Light",
     "Material2.Light": "Theme.EdgeToEdge.Material2.Light",
     "Material3.Light": "Theme.EdgeToEdge.Material3.Light",
     "Material3.Dynamic.Light": "Theme.EdgeToEdge.Material3.Dynamic.Light",
+    "Material3Expressive.Light": "Theme.EdgeToEdge.Material3Expressive.Light",
+    "Material3Expressive.Dynamic.Light": "Theme.EdgeToEdge.Material3Expressive.Dynamic.Light"
   };
 
   const cleanupList = new Set([


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please follow the template so that the reviewers can easily understand what the code changes affect -->

# Summary
This PR adds support for the new Material 3 Expressive styles. There are some components that Google has released that only work with the `Material3Expressive` theme (like the new loading indicator). Read more about M3 expressive [here](https://m3.material.io/blog/building-with-m3-expressive#what-rsquo-s-in-the-update). [Here are the Android docs](https://github.com/material-components/material-components-android/blob/master/docs/getting-started.md#material3expressive-themes) on how to install it as well.
<!--
Explain the **motivation** for making this change: here are some points to help you:

* What issues does the pull request solve? Please tag them so that they will get automatically closed once the PR is merged
* What is the feature? (if applicable)
* How did you implement the solution?
* What areas of the library does it impact?
-->

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI. -->

### What's required for testing (prerequisites)?
Update your Android app theme to inherit from one of the new Material3Expressive themes. Click through all the buttons in the sample app and see they all still behave the same.

### What are the steps to test it (after prerequisites)?

## Compatibility

| OS      | Implemented |
| ------- | :---------: |
| iOS     |    ❌     |
| Android |    ✅     |

## Checklist

<!-- Check completed item, when applicable, via: [X] -->

- [x] I have tested this on a device and a simulator
- [x] I added the documentation in `README.md`
- [ ] I added a sample use of the API in the example project (`example/src/App.tsx`)
